### PR TITLE
V1495 BCM Decoding is now working

### DIFF
--- a/replay/RHRS.odef
+++ b/replay/RHRS.odef
@@ -22,9 +22,8 @@ variable RTDC.F1AllHits_014
 #variable vfFirstHit
 #variable vfAllHits_126
 
-# V1495 Clock Count
-variable RV1495.ClockCount
-variable RV1495.ClockInterval
+# V1495 Clock Count and BCM
+block RV1495.*
 
 # Physics variables
 #block RightBCM*

--- a/replay/libraries/TriV1495/ClockCountEvtHandler.cxx
+++ b/replay/libraries/TriV1495/ClockCountEvtHandler.cxx
@@ -177,6 +177,10 @@ if(V1495!=0){
 	V1495ClockCount = 0;
 	if (fDebug) cout << "Before V1495->GetCount()     V1495ClockCount = " << hex << V1495ClockCount << dec << endl;
 	V1495ClockCount = V1495->GetCount();
+	V1495BCMuh = V1495->GetBCM(0); //upstream BCM, high bits
+	V1495BCMul = V1495->GetBCM(1); //upstream BCM, low bits
+	V1495BCMdh = V1495->GetBCM(2); //downstream BCM, high bits
+	V1495BCMdl = V1495->GetBCM(3); //downstream BCM, low bits
 	if (fDebug) cout << "After V1495->GetCount()      V1495ClockCount = " << hex << V1495ClockCount << dec << endl;
 	V1495ClockInterval = 0;
 	V1495ClockInterval = V1495ClockCount - V1495PrevCount;
@@ -200,6 +204,10 @@ THaAnalysisObject::EStatus ClockCountEvtHandler::Init(const TDatime& date)
   // data keys to look for in this fun example
   dataKeys.push_back(nameArm1495 + ".ClockCount");
   dataKeys.push_back(nameArm1495 + ".ClockInterval");
+  dataKeys.push_back(nameArm1495 + ".BCMuh");
+  dataKeys.push_back(nameArm1495 + ".BCMul");
+  dataKeys.push_back(nameArm1495 + ".BCMdh");
+  dataKeys.push_back(nameArm1495 + ".BCMdl");
 
   // initialize map elements to -1 (means not found yet)
   for (UInt_t i=0; i < dataKeys.size(); i++) {
@@ -229,6 +237,19 @@ THaAnalysisObject::EStatus ClockCountEvtHandler::Init(const TDatime& date)
   // for Clock Interval
   V1495ClockInterval = 0;
   gHaVars->DefineByType(dataKeys[numEntries].c_str(), "ClockInterval", &V1495ClockInterval, kUInt, 0);
+  numEntries++;
+  // for BCM
+  V1495BCMuh = 0;
+  gHaVars->DefineByType(dataKeys[numEntries].c_str(), "BCMuh", &V1495BCMuh, kUInt, 0);
+  numEntries++;
+  V1495BCMul = 0;
+  gHaVars->DefineByType(dataKeys[numEntries].c_str(), "BCMul", &V1495BCMul, kUInt, 0);
+  numEntries++;
+  V1495BCMdh = 0;
+  gHaVars->DefineByType(dataKeys[numEntries].c_str(), "BCMdh", &V1495BCMdh, kUInt, 0);
+  numEntries++;
+  V1495BCMdl = 0;
+  gHaVars->DefineByType(dataKeys[numEntries].c_str(), "BCMdl", &V1495BCMdl, kUInt, 0);
   numEntries++;
   
   fStatus = kOK;

--- a/replay/libraries/TriV1495/ClockCountEvtHandler.cxx
+++ b/replay/libraries/TriV1495/ClockCountEvtHandler.cxx
@@ -177,10 +177,8 @@ if(V1495!=0){
 	V1495ClockCount = 0;
 	if (fDebug) cout << "Before V1495->GetCount()     V1495ClockCount = " << hex << V1495ClockCount << dec << endl;
 	V1495ClockCount = V1495->GetCount();
-	V1495BCMuh = V1495->GetBCM(0); //upstream BCM, high bits
-	V1495BCMul = V1495->GetBCM(1); //upstream BCM, low bits
-	V1495BCMdh = V1495->GetBCM(2); //downstream BCM, high bits
-	V1495BCMdl = V1495->GetBCM(3); //downstream BCM, low bits
+	V1495BCMu = V1495->GetBCM(0); //upstream BCM
+	V1495BCMd = V1495->GetBCM(1); //downstream BCM
 	if (fDebug) cout << "After V1495->GetCount()      V1495ClockCount = " << hex << V1495ClockCount << dec << endl;
 	V1495ClockInterval = 0;
 	V1495ClockInterval = V1495ClockCount - V1495PrevCount;
@@ -204,10 +202,8 @@ THaAnalysisObject::EStatus ClockCountEvtHandler::Init(const TDatime& date)
   // data keys to look for in this fun example
   dataKeys.push_back(nameArm1495 + ".ClockCount");
   dataKeys.push_back(nameArm1495 + ".ClockInterval");
-  dataKeys.push_back(nameArm1495 + ".BCMuh");
-  dataKeys.push_back(nameArm1495 + ".BCMul");
-  dataKeys.push_back(nameArm1495 + ".BCMdh");
-  dataKeys.push_back(nameArm1495 + ".BCMdl");
+  dataKeys.push_back(nameArm1495 + ".BCMu");
+  dataKeys.push_back(nameArm1495 + ".BCMd");
 
   // initialize map elements to -1 (means not found yet)
   for (UInt_t i=0; i < dataKeys.size(); i++) {
@@ -239,17 +235,11 @@ THaAnalysisObject::EStatus ClockCountEvtHandler::Init(const TDatime& date)
   gHaVars->DefineByType(dataKeys[numEntries].c_str(), "ClockInterval", &V1495ClockInterval, kUInt, 0);
   numEntries++;
   // for BCM
-  V1495BCMuh = 0;
-  gHaVars->DefineByType(dataKeys[numEntries].c_str(), "BCMuh", &V1495BCMuh, kUInt, 0);
+  V1495BCMu = 0;
+  gHaVars->DefineByType(dataKeys[numEntries].c_str(), "BCMu", &V1495BCMu, kULong, 0);
   numEntries++;
-  V1495BCMul = 0;
-  gHaVars->DefineByType(dataKeys[numEntries].c_str(), "BCMul", &V1495BCMul, kUInt, 0);
-  numEntries++;
-  V1495BCMdh = 0;
-  gHaVars->DefineByType(dataKeys[numEntries].c_str(), "BCMdh", &V1495BCMdh, kUInt, 0);
-  numEntries++;
-  V1495BCMdl = 0;
-  gHaVars->DefineByType(dataKeys[numEntries].c_str(), "BCMdl", &V1495BCMdl, kUInt, 0);
+  V1495BCMd = 0;
+  gHaVars->DefineByType(dataKeys[numEntries].c_str(), "BCMd", &V1495BCMd, kULong, 0);
   numEntries++;
   
   fStatus = kOK;

--- a/replay/libraries/TriV1495/ClockCountEvtHandler.h
+++ b/replay/libraries/TriV1495/ClockCountEvtHandler.h
@@ -38,10 +38,8 @@ private:
    UInt_t V1495ClockCount;
    UInt_t V1495PrevCount;
    UInt_t V1495ClockInterval;
-   UInt_t V1495BCMuh;
-   UInt_t V1495BCMul;
-   UInt_t V1495BCMdh;
-   UInt_t V1495BCMdl;
+   ULong_t V1495BCMu;
+   ULong_t V1495BCMd;
    std::string nameArm1495;
 
    ClockCountEvtHandler(const ClockCountEvtHandler& fh);

--- a/replay/libraries/TriV1495/ClockCountEvtHandler.h
+++ b/replay/libraries/TriV1495/ClockCountEvtHandler.h
@@ -9,6 +9,7 @@
 //   author  Robert Michaels (rom@jlab.org)
 //
 //   modified into ClockCountEvtHandler by Evan McClellan -- 2018-02-01
+//   added BCM readout -- Evan McClellan -- 2019-01-08
 /////////////////////////////////////////////////////////////////////
 
 #include "THaEvtTypeHandler.h"
@@ -37,6 +38,10 @@ private:
    UInt_t V1495ClockCount;
    UInt_t V1495PrevCount;
    UInt_t V1495ClockInterval;
+   UInt_t V1495BCMuh;
+   UInt_t V1495BCMul;
+   UInt_t V1495BCMdh;
+   UInt_t V1495BCMdl;
    std::string nameArm1495;
 
    ClockCountEvtHandler(const ClockCountEvtHandler& fh);

--- a/replay/libraries/TriV1495/V1495Module.h
+++ b/replay/libraries/TriV1495/V1495Module.h
@@ -31,6 +31,7 @@ public:
 
    Int_t Decode(const UInt_t *p) { return 0; };
    UInt_t GetCount();
+   UInt_t GetBCM(UInt_t);
 
    // Loads slot data for bank structures
    virtual Int_t LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer, Int_t pos, Int_t len);
@@ -41,6 +42,10 @@ private:
 
 
    UInt_t *vCount;
+   UInt_t *vBCMuh;
+   UInt_t *vBCMul;
+   UInt_t *vBCMdh;
+   UInt_t *vBCMdl;
 
    Bool_t IsInit;
    static TypeIter_t fgThisType;

--- a/replay/libraries/TriV1495/V1495Module.h
+++ b/replay/libraries/TriV1495/V1495Module.h
@@ -31,7 +31,7 @@ public:
 
    Int_t Decode(const UInt_t *p) { return 0; };
    UInt_t GetCount();
-   UInt_t GetBCM(UInt_t);
+   ULong_t GetBCM(UInt_t);
 
    // Loads slot data for bank structures
    virtual Int_t LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer, Int_t pos, Int_t len);
@@ -42,10 +42,8 @@ private:
 
 
    UInt_t *vCount;
-   UInt_t *vBCMuh;
-   UInt_t *vBCMul;
-   UInt_t *vBCMdh;
-   UInt_t *vBCMdl;
+   ULong_t *vBCMu;
+   ULong_t *vBCMd;
 
    Bool_t IsInit;
    static TypeIter_t fgThisType;


### PR DESCRIPTION
Updated and testing V1495 BCM decoding for the Right arm for run 111938. It works.

The left arm V1495 firmware is not yet recording the BCM values. For the left arm, the decoder correctly decoded the ClockCount and ClockInterval while ignoring the 'missing' BCM information.

Changed the RHRS.odef to include the two new variables: RV1495.BCMu and RV1495.BCMd